### PR TITLE
introduce template options for displaying commit sha

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The template for the blame message that will be shown.
 
 Default: `'<committer>, <committer-time> • <summary>'`
 
-Available options: `<author>`, `<author-mail>`, `<author-time>`, `<committer>`, `<committer-mail>`, `<committer-time>`, `<summary>`.
+Available options: `<author>`, `<author-mail>`, `<author-time>`, `<committer>`, `<committer-mail>`, `<committer-time>`, `<summary>`, `<commit-short>`, `<commit-long>`.
 
 ```
 let g:blamer_template = '<committer> <summary>'

--- a/autoload/blamer.vim
+++ b/autoload/blamer.vim
@@ -73,7 +73,7 @@ function! blamer#GetMessage(file, line_number, line_count) abort
   let l:info = {}
   let l:info['commit-short'] = split(l:lines[0], ' ')[0][:7]
   let l:info['commit-long'] = split(l:lines[0], ' ')[0]
-  for line in l:lines
+  for line in l:lines[1:]
     let l:words = split(line, ' ')
     let l:property = l:words[0]
     let l:value = join(l:words[1:], ' ')

--- a/autoload/blamer.vim
+++ b/autoload/blamer.vim
@@ -71,6 +71,8 @@ function! blamer#GetMessage(file, line_number, line_count) abort
 
   let l:lines = split(l:result, '\n')
   let l:info = {}
+  let l:info['commit-short'] = split(l:lines[0], ' ')[0][:7]
+  let l:info['commit-long'] = split(l:lines[0], ' ')[0]
   for line in l:lines
     let l:words = split(line, ' ')
     let l:property = l:words[0]


### PR DESCRIPTION
Nice plugin. I was missing the commit sha as an option so I added it myself and thought might be useful for other to have.