### PR TITLE
Silence fatal file length messages.

### DIFF
--- a/autoload/blamer.vim
+++ b/autoload/blamer.vim
@@ -68,6 +68,8 @@ function! blamer#GetMessage(file, line_number, line_count) abort
       return ''
     elseif l:result =~? 'is outside repository'
       return ''
+    elseif l:result =~? 'has only' && l:result =~? 'lines'
+      return ''
     else
       echo '[blamer.nvim] ' . l:result
       return ''


### PR DESCRIPTION
Thanks for the great plugin! I installed it a few days ago and have been enjoying it.

Suppresses the following exception

    [blamer.nvim] fatal: file ... has only ... lines

This occurs when the line being blamed does not yet exist in git. This
occurs often when appending to an existing file that is checked in.