### PR TITLE
Suppress error in git repo with no commits

### DIFF
--- a/autoload/blamer.vim
+++ b/autoload/blamer.vim
@@ -117,6 +117,8 @@ function! blamer#GetMessage(file, line_number, line_count) abort
       return ''
     elseif l:result =~? 'has only' && l:result =~? 'lines'
       return ''
+    elseif l:result =~? 'no such ref'
+      return ''
     endif
 
     " Echo unkown errors in order to catch them


### PR DESCRIPTION
Hi,

Thank you for this plugin I love it, and use it every day!

This PR suppress fix an annoying error message happening if you are using blamer.nvim in a new git repo with no HEAD. In this case git will return the error: `no such ref: HEAD`.