### PR TITLE
Shell escape file path before blaming

### DIFF
--- a/autoload/blamer.vim
+++ b/autoload/blamer.vim
@@ -92,7 +92,8 @@ function! s:GetLines() abort
 endfunction
 
 function! blamer#GetMessage(file, line_number, line_count) abort
-  let l:command = 'git --no-pager blame -p -L ' . a:line_number . ',' . a:line_count . ' -- ' . a:file
+  let l:file_path_escaped = shellescape(a:file)
+  let l:command = 'git --no-pager blame -p -L ' . a:line_number . ',' . a:line_count . ' -- ' . l:file_path_escaped
   let l:result = system(l:command)
 
   let l:lines = split(l:result, '\n')

--- a/autoload/blamer.vim
+++ b/autoload/blamer.vim
@@ -122,7 +122,7 @@ function! blamer#GetMessage(file, line_number, line_count) abort
       return ''
     endif
 
-    " Echo unkown errors in order to catch them
+    " Echo unknown errors in order to catch them
     echo '[blamer.nvim] ' . l:result
     return ''
   endif


### PR DESCRIPTION
I have file paths that include single quotes, so running git blame within `system(l:command)` throws an error `[blamer.nvim] zsh:1: unmatched '`. This change escapes the path to fix the problem.