### PR TITLE
Judge git repo exist by file instead of cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Enables blamer on (neo)vim startup.
 
 You can toggle blamer on/off with the `:BlamerToggle` command.
 
-If the current directory is not a git repository the blamer will be automatically disabled.
+If the current file is not belong to a git repository, the blamer will be temporarily disabled, util next time enter a buffer which in a git repository.
 
 Default: `0`
 

--- a/autoload/blamer.vim
+++ b/autoload/blamer.vim
@@ -196,12 +196,13 @@ function! blamer#CreatePopup(buffer_number, line_number, message) abort
 endfunction
 
 function! blamer#Show() abort
-  if g:blamer_enabled == 0 || s:git_root == ''
+  if g:blamer_enabled == 0
     return
   endif
 
-  let l:is_buffer_special = &buftype != '' ? 1 : 0
-  if is_buffer_special
+  if &buftype != '' | return | endif    " don't handle special buffer
+
+  if s:git_root == ''
     return
   endif
 
@@ -244,6 +245,7 @@ function! blamer#Refresh() abort
   if g:blamer_enabled == 0
     return
   endif
+  if &buftype != '' | return | endif    " don't handle special buffer
 
   call timer_stop(s:blamer_timer_id)
   call blamer#Hide()
@@ -274,14 +276,7 @@ function! blamer#Disable() abort
 endfunction
 
 function! blamer#CheckGitRepoExist() abort
-  let l:file_path = s:substitute_path_separator(expand('%:h'))
-
-  if s:is_windows
-    let l:result = split(system('git -C ' . l:file_path . ' rev-parse --show-toplevel 2>NUL'), '\n')
-  else
-    let l:result = split(system('git -C ' . l:file_path . ' rev-parse --show-toplevel 2>/dev/null'), '\n')
-  endif
-  let s:git_root = s:Head(l:result)
+  let s:git_root = finddir('.git/..', expand('%:p:h').';')
 
   return s:git_root == '' ? 0 : 1
 endfunction


### PR DESCRIPTION
The behavior that disable blamer when current working
directory is not belong to a git root is not suitable
for some use case. User may switch between git repo
and none git repo, plugin should not be disabled forever.
In this patch, git root is detected on every buffer
enter. Once we in the git repo, we start to refresh
the blame information.  If we are not in git repo,
disable the autocmd for no overhead.