### PR TITLE
Fix blamer not working when initially blamer_enabled=0

### DIFF
--- a/autoload/blamer.vim
+++ b/autoload/blamer.vim
@@ -336,6 +336,7 @@ endfunction
 
 function! blamer#Enable() abort
   let g:blamer_enabled = 1
+  let s:blamer_buffer_enabled = blamer#IsBufferGitTracked()
 endfunction
 
 function! blamer#Disable() abort
@@ -363,10 +364,6 @@ function! blamer#DisableShow() abort
 endfunction
 
 function! blamer#Init() abort
-  if g:blamer_enabled == 0
-    return
-  endif
-
   if g:blamer_is_initialized == 1
     return
   endif


### PR DESCRIPTION
Closes #41 

Looks like the issue was caused from the introduction of `blamer_buffer_enabled` and removal of `blamer#Init()` from `blamer#Enable()` in [refactor code to better handle enable/disable cases](https://github.com/APZelos/blamer.nvim/commit/8e58a6f44c49959be0518f89d8f1f408928aba78).

Instead of reverting these changes, I tried to accommodate the improvements the changes seem like they were supposed to provide (specifically `blamer_buffer_enabled`).

Changes:

- set `blamer_buffer_enabled` in `blamer#Enable()` to determine whether buffer is git tracked
- removed the `blamer_enabled` check in `blamer#Init()` since it doesn't make sense for an init func to be called outside of it's initialisation. Keeping the `blamer_enabled` check and making `blamer#Enable()` call `blamer#Init()` like it did before would fix the refreshing of blamer, but I don't think it's a good design choice.

