### PR TITLE
validate nvim_buf_set_extmark existance

### DIFF
--- a/autoload/blamer.vim
+++ b/autoload/blamer.vim
@@ -195,7 +195,11 @@ endfunction
 
 function! blamer#SetVirtualText(buffer_number, line_number, message) abort
   let l:line_index = a:line_number - 1
-  call nvim_buf_set_extmark(a:buffer_number, s:blamer_namespace, l:line_index, 0, {"hl_mode": "combine", "virt_text": [[s:blamer_prefix . a:message, 'Blamer']]})
+  if exists('*nvim_buf_set_extmark')
+    call nvim_buf_set_extmark(a:buffer_number, s:blamer_namespace, l:line_index, 0, {"hl_mode": "combine", "virt_text": [[s:blamer_prefix . a:message, 'Blamer']]})
+  else
+    call nvim_buf_set_virtual_text(a:buffer_number, s:blamer_namespace, l:line_index, [[s:blamer_prefix . a:message, 'Blamer']], {})
+  endif
 endfunction
 
 function! blamer#CreatePopup(buffer_number, line_number, message) abort
@@ -237,7 +241,7 @@ function! blamer#Show() abort
 
   let l:file_path = s:substitute_path_separator(expand('%:p'))
 
-  if empty(l:file_path) 
+  if empty(l:file_path)
     return
   endif
 
@@ -288,7 +292,7 @@ endfunction
 
 function! blamer#IsBufferGitTracked() abort
   let l:file_path = shellescape(s:substitute_path_separator(expand('%:p')))
-  if empty(l:file_path) 
+  if empty(l:file_path)
     return 0
   endif
 


### PR DESCRIPTION
This fixes the issue 52 
> Commit [ab4dc40](https://github.com/APZelos/blamer.nvim/commit/ab4dc40a1df02ede465e09039c38922db3aceadb) breaks blamer, cannot find the correct function which locks navigation between files, rolling back to the previous function fixed it temporarily
> 
> ```shell
> Error detected while processing function <lambda>41[1]..blamer#Show[31]..blamer#SetVirtualText:
> line    3:
> E117: Unknown function: nvim_buf_set_extmark
> ```
> 
> ![image](https://user-images.githubusercontent.com/51766256/141021987-2b60bd99-007e-4134-92e2-03e87f0fd3e8.png)
> 
> Error in
> 
> https://github.com/APZelos/blamer.nvim/blob/ab4dc40a1df02ede465e09039c38922db3aceadb/autoload/blamer.vim#L198
