### PR TITLE
Fix determine whether a path is empty

### DIFF
--- a/autoload/blamer.vim
+++ b/autoload/blamer.vim
@@ -291,10 +291,11 @@ endfunction
 
 
 function! blamer#IsBufferGitTracked() abort
-  let l:file_path = shellescape(s:substitute_path_separator(expand('%:p')))
-  if empty(l:file_path)
+  let l:path = expand('%:p')
+  if empty(l:path)
     return 0
   endif
+  let l:file_path = shellescape(s:substitute_path_separator(l:path))
 
   let l:dir_path = shellescape(s:substitute_path_separator(expand('%:h')))
   let l:result = system('git -C ' . l:dir_path . ' ls-files --error-unmatch ' . l:file_path)


### PR DESCRIPTION
If we call `expand('%p')` in a unnamed buffer, we will get an empty
string "". `shellescape("")` returns an escaped string "''" which
is not empty. So the determine whether a path is empty in current
code takes no effect.

Determine the emptyness using result of `expand('%p')` fixes this bug.