### PR TITLE
fatal: file ... has only 1 line

### DIFF
--- a/autoload/blamer.vim
+++ b/autoload/blamer.vim
@@ -148,7 +148,7 @@ function! blamer#GetMessages(file, line_number, line_count) abort
       return ''
     elseif l:result =~? 'is outside repository'
       return ''
-    elseif l:result =~? 'has only' && l:result =~? 'lines'
+    elseif l:result =~? 'has only' && l:result =~? 'lines\?'
       return ''
     elseif l:result =~? 'no such ref'
       return ''


### PR DESCRIPTION
This patches the following commit to handle the singular case (only one file):

https://github.com/APZelos/blamer.nvim/commit/9222aa3a702112da2336f0dbb06922b4d8e01f55